### PR TITLE
clarify GitHub HTTPS docs, add a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+*.egg-info/
+__pycache__/

--- a/prs_and_reviewing.md
+++ b/prs_and_reviewing.md
@@ -60,6 +60,7 @@ You can use HTTPS:
 
 GitHub has turned off password authentication, so you will need to set up token access for HTTPS.
 Follow these [instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic) to generate a token, and then use it in place of your password.
+When generating the token, just grant it the `repo` scope.
 
 You can also authenticate with ssh (follow the [instructions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) ).
 If you use GitHub a lot, enabling 2-factor authentication and ssh is a good idea (it also means
@@ -185,7 +186,9 @@ an idea of roughly what each commit does.
 
 You can now check that your commit is in the history using:
 
-    git log
+    git log -n 5
+
+Type `d` to keep scrolling through the output, and `q` to quit.
 
 If the commit is there, you are now ready to push your changes to GitHub! You can do this using:
 


### PR DESCRIPTION
This adds 3 changes, described below.

### clarify GitHub token scope

I tested the "use an HTTPS remote + a GitHub personal access token" approach for pulling / pushing. Found that everything in this BoF can be done with only the `"repo"` token scope. That isn't enabled by default in the GitHub UI, so I think it's worth documenting for people going through the tutorial.

### add a `.gitignore`

I ran all the sample code, and found a few files were left behind (like a `.egg-info` directory from running `pip install`). This proposes gitignore-ing them, to make it harder for people to accidentally commit them.

### clarify how to work with the output of `git log`

In its default configuration, `git log` drops you into `less`, where you have to use the `u` / `d` keys to scroll and the `q` key to quit.