### PR TITLE
fix to doc (example factorial result was incorrect)

### DIFF
--- a/participants/scipy_053/doc/README.md
+++ b/participants/scipy_053/doc/README.md
@@ -3,7 +3,7 @@ functions that do stuf and thats:
 
     >>> from simple_functions import factorial
     >>> factorial(10)
-    9
+    3628800
 
 and this other part does something.  I forget why that I did it:
 


### PR DESCRIPTION
the documentation incorrectly said factorial(10) was 9.  Fixed the documentation to represent the correct answer.